### PR TITLE
Add mute parameter

### DIFF
--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -18,6 +18,7 @@ export type HirCodegenOpts = {
    * For some reason ts-pattern allows you to pattern match on arbitrary types that are unrelated to the expression being matched upon. As a result, optional chaining `foo?.bar?.baz` is necessary to avoid `property of undefined` errors. This incurs an additional runtime overhead, but you can disable it here.
    * */
   disableOptionalChaining: boolean;
+  mute?: boolean
 };
 export type HirCodegen = (
   | {

--- a/src/pattycake.ts
+++ b/src/pattycake.ts
@@ -113,7 +113,9 @@ const pattycakePlugin = (opts: Opts): PluginObj => {
             }
           }
         } catch (err) {
-          console.error(err);
+          if (!opts.mute) {
+            console.error(err);
+          }
         }
       },
     },


### PR DESCRIPTION
Currently, my console can get clogged up with messages like `Error: unimplemented Identifier` from this library. While you work on implementing the rest of `ts-pattern`'s features, it would be nice to be able to mute these messages.

This PR enables a `mute` flag that you can include in your next.config:

`config = pattycake.next(config, { mute: true });`